### PR TITLE
build(pypi): Constrain the python version

### DIFF
--- a/connectorx-python/pyproject.toml
+++ b/connectorx-python/pyproject.toml
@@ -24,6 +24,7 @@ version = "0.3.2"
 name = "connectorx" # Target file name of maturin build
 readme = "README.md"
 license = { text = "MIT" }
+requires-python = ">=3.8"
 
 [tool.poetry.dependencies]
 dask = {version = "^2021", optional = true, extras = ["dataframe"]}


### PR DESCRIPTION
I have a py3.7 only project, which is managed by poetry.
But I found that the `connectorx` library does not constrain the python version in the lock file, so It will try to install `connectorx==0.3.2` which has deprecated py3.7 and ultimately fail.